### PR TITLE
[Feat] Issue 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,16 +2,20 @@ import './App.css';
 import Detail from './pages/Detail';
 import Issue from './pages/Issue';
 import NotFound from './pages/NotFound';
+import GlobalStyle from './styles/GlobalStyle';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 function App() {
   return (
-    <Routes>
-      <Route path='/' element={<Issue />} />
-      <Route path='/:number' element={<Detail />} />
-      <Route path='/*' element={<Navigate to='/error' />} />
-      <Route path='/error' element={<NotFound />} />
-    </Routes>
+    <>
+      <GlobalStyle />
+      <Routes>
+        <Route path='/' element={<Issue />} />
+        <Route path='/:number' element={<Detail />} />
+        <Route path='/*' element={<Navigate to='/error' />} />
+        <Route path='/error' element={<NotFound />} />
+      </Routes>
+    </>
   );
 }
 

--- a/src/components/Ad.tsx
+++ b/src/components/Ad.tsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+import { styled } from 'styled-components';
+
+export default function Ad() {
+  return (
+    <StyledAd>
+      <Link to='https://www.wanted.co.kr/jobsfeed'>
+        <img
+          src='https://github.com/hyeri-woo/wanted-pre-onboarding-frontend/assets/107099724/d5be6d63-52a6-4260-8e19-660ea350f05c'
+          alt='광고 배너'
+        />
+      </Link>
+    </StyledAd>
+  );
+}
+
+const StyledAd = styled.article``;

--- a/src/components/issue/IssueItem.tsx
+++ b/src/components/issue/IssueItem.tsx
@@ -1,5 +1,28 @@
-import React from 'react';
+import { Issue } from '../../types';
+import { Link } from 'react-router-dom';
+import { styled } from 'styled-components';
 
-export default function IssueItem() {
-  return <div>IssueItem</div>;
+interface Props {
+  issue: Issue;
 }
+
+export default function IssueItem({ issue }: Props) {
+  return (
+    <StyledItem>
+      <Link to={`/${issue.number}`}>
+        <h2>
+          <span className='issue-num'>#{issue.number}</span> {issue.title}
+        </h2>
+        <p className='header-info'>
+          <span className='author'>{issue.author}</span>
+          <span className='time'>
+            작성일: {issue.date.slice(0, 10)} {issue.date.slice(11, 19)}
+          </span>
+          <span className='comment'>댓글: {issue.comments}</span>
+        </p>
+      </Link>
+    </StyledItem>
+  );
+}
+
+const StyledItem = styled.div``;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,13 +9,11 @@ import { BrowserRouter } from 'react-router-dom';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </Provider>
-  </React.StrictMode>,
+  <Provider store={store}>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </Provider>,
 );
 
 reportWebVitals();

--- a/src/pages/Issue.tsx
+++ b/src/pages/Issue.tsx
@@ -1,5 +1,49 @@
-import React from 'react';
+import Ad from '../components/Ad';
+import Header from '../components/common/Header';
+import IssueItem from '../components/issue/IssueItem';
+import { fetchIssue } from '../redux/slices/issue';
+import { AppDispatch, RootState } from '../redux/store';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { styled } from 'styled-components';
 
 export default function Issue() {
-  return <div>Issue</div>;
+  const issues = useSelector((state: RootState) => state.issueList);
+  const { organization, repository } = useSelector((state: RootState) => state.issueOption);
+  const dispatch = useDispatch<AppDispatch>();
+
+  useEffect(() => {
+    dispatch(
+      fetchIssue({
+        organization: organization,
+        repository: repository,
+        page: issues.page,
+      }),
+    );
+  }, []);
+
+  return (
+    <>
+      <Header />
+      <StyledIssueList>
+        {issues.data.length > 0 &&
+          issues.data.map((issue, index) => {
+            return (
+              <>
+                <li key={issue.number}>
+                  <IssueItem issue={issue} />
+                </li>
+                {(index + 1) % 4 === 0 && (
+                  <li>
+                    <Ad />
+                  </li>
+                )}
+              </>
+            );
+          })}
+      </StyledIssueList>
+    </>
+  );
 }
+
+const StyledIssueList = styled.ul``;

--- a/src/redux/slices/issue.ts
+++ b/src/redux/slices/issue.ts
@@ -1,5 +1,6 @@
 import { fetchGetIssues, LOAD_DATA_LENGTH } from '../../api/issue';
 import { Issue } from '../../types';
+import { IssueOptions } from './issueOption';
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export interface IssueState {
@@ -10,9 +11,7 @@ export interface IssueState {
   hasMore: boolean;
 }
 
-export interface GetIssueOptions {
-  organization: string;
-  repository: string;
+export interface GetIssueOptions extends IssueOptions {
   page: number;
 }
 

--- a/src/redux/slices/issueDetail.ts
+++ b/src/redux/slices/issueDetail.ts
@@ -1,5 +1,6 @@
 import { fetchGetIssueDetail } from '../../api/issue';
 import { Issue } from '../../types';
+import { IssueOptions } from './issueOption';
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export interface IssueDetailState {
@@ -14,9 +15,7 @@ const initialState = {
   error: null as string | null,
 };
 
-export interface GetIssueDetailOptions {
-  organization: string;
-  repository: string;
+export interface GetIssueDetailOptions extends IssueOptions {
   issueNumber: number;
 }
 

--- a/src/redux/slices/issueOption.ts
+++ b/src/redux/slices/issueOption.ts
@@ -1,0 +1,17 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export interface IssueOptions {
+  organization: string;
+  repository: string;
+}
+
+const initialState: IssueOptions = {
+  organization: 'facebook',
+  repository: 'react',
+};
+
+export const issueOptionSlice = createSlice({
+  name: 'issueOption',
+  initialState,
+  reducers: {},
+});

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,10 +1,12 @@
 import { issueSlice } from './slices/issue';
 import { issueDetailSlice } from './slices/issueDetail';
+import { issueOptionSlice } from './slices/issueOption';
 import { Action, combineReducers, configureStore, ThunkAction } from '@reduxjs/toolkit';
 
 const reducer = combineReducers({
   issueList: issueSlice.reducer,
   issueDetail: issueDetailSlice.reducer,
+  issueOption: issueOptionSlice.reducer,
 });
 
 export const store = configureStore({

--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -5,7 +5,7 @@ const GlobalStyle = createGlobalStyle`
         margin: 0;
         padding: 0;
         box-sizing: border-box;
-        color: white;
+        /* color: white; */
     }
     html, body, #root {
     }


### PR DESCRIPTION
- IssueItem 컴포넌트 구현
- Ad 컴포넌트 구현
- issueOption redux 분리 (Issue/Detail/Header에서 접근할 수 있도록) => slices/issue, slices/issueDetail에 있는 Option interface 변경
- GlobalStyle (리셋용)으로 1차 디자인